### PR TITLE
Fixing default scope

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -7,7 +7,6 @@ class PatientsController < ApplicationController
   def create
     @patient = Patient.new(patient_params)
     @case = Case.find(params[:case_id])
-      raise
 
     if @patient.save
       # case/show page, when patient created successfully

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -6,7 +6,8 @@ class Case < ApplicationRecord
 
   accepts_nested_attributes_for :patient
 
-  default_scope { order("created_at DESC") }
+  default_scope { order(created_at: :desc) }
+
   include PgSearch::Model
   pg_search_scope :search_by_name_and_description,
                   against: [:title, :description],


### PR DESCRIPTION
Heroku was raising

```
2021-03-09T03:01:37.997707+00:00 app[web.1]: [a3b220f3-59e7-4e39-9441-1b025d2d6e65] ActionView::Template::Error (PG::AmbiguousColumn: ERROR:  column reference "created_at" is ambiguous
```

This is because rails couldn't identify how to order the case list.
With the correct syntax, it won't fail anymore.

Reminder to the future: avoid to use `"created_at DESC"` in a scope, or even in a query. prefer to use it with a symbol, or, explicitly use the table name:

`default_scope { order("cases.created_at DESC") }`